### PR TITLE
Fix error with missmatching Qt and Boost versions

### DIFF
--- a/qt_create/src/qt_create/templates/qt-ros/include/PACKAGE_NAME/qnode.hpp
+++ b/qt_create/src/qt_create/templates/qt-ros/include/PACKAGE_NAME/qnode.hpp
@@ -16,7 +16,9 @@
 ** Includes
 *****************************************************************************/
 
+#ifndef Q_MOC_RUN
 #include <ros/ros.h>
+#endif
 #include <string>
 #include <QThread>
 #include <QStringListModel>

--- a/qt_create/src/qt_create/templates/qt-ros/include/PACKAGE_NAME/qnode.hpp
+++ b/qt_create/src/qt_create/templates/qt-ros/include/PACKAGE_NAME/qnode.hpp
@@ -16,6 +16,8 @@
 ** Includes
 *****************************************************************************/
 
+// To workaround boost/qt4 problems that won't be bugfixed. Refer to
+//    https://bugreports.qt.io/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
 #include <ros/ros.h>
 #endif


### PR DESCRIPTION
I encountered this error when trying to compile the generated qnode in ubuntu 16.04 with ros kinetic (Qt-version: 4.8.7, Boost Version 1.58). There seem to be multiple other users that have similar problems:
http://answers.ros.org/question/233786/parse-error-at-boost_join/